### PR TITLE
métodos getRoot()

### DIFF
--- a/src/MerkleTreePrefix.ts
+++ b/src/MerkleTreePrefix.ts
@@ -580,12 +580,14 @@ export class MerkleTreePrefix extends Base {
    *const root = tree.getRoot()
    *```
    */
-  getRoot ():Buffer {
-    if (this.layers.length === 0) {
-      return Buffer.from([])
-    }
-
-    return this.layers[this.layers.length - 1][0] || Buffer.from([])
+  getRoot (): TLeafPref {
+    if (this.layers.length === 0) 
+      return {
+        leaf: Buffer.from([]),
+        vote: [[]]
+      }
+      
+    return this.layers[this.layers.length - 1][0]
   }
 
   /**
@@ -597,10 +599,13 @@ export class MerkleTreePrefix extends Base {
    *const root = tree.getHexRoot()
    *```
    */
-  getHexRoot ():string {
-    return this.bufferToHex(this.getRoot())
+   getHexRoot (): object {
+   return {
+      leaf: this.bufferToHex(this.getRoot().leaf),
+      vote: this.getRoot().vote
+    } 
   }
-
+ 
   /**
    * getProof
    * @desc Returns the proof for a target leaf.

--- a/src/MerkleTreePrefix.ts
+++ b/src/MerkleTreePrefix.ts
@@ -436,11 +436,13 @@ export class MerkleTreePrefix extends Base {
    *const leaves = tree.getHexLeaves()
    *```
    */
-   /* TODO
-  getHexLeaves ():string[] {
-    return this.leaves.map(leaf => this.bufferToHex(leaf))
+  getHexLeaves ():object[] { 
+    return this.leaves.map(l => ({ 
+      leaf: this.bufferToHex(l.leaf), 
+      vote: l.vote 
+    })) 
   }
-  */
+
   /**
    * marshalLeaves
    * @desc Returns array of leaves of Merkle Tree as a JSON string.


### PR DESCRIPTION
Tentei modificar o getRoot() para conseguir ver no logs-transparentes a raiz da árvore. Aparentemente está funcionando: 

![image](https://user-images.githubusercontent.com/77642873/197914072-6e1adb6f-9bbd-40ee-aeb9-ffe5a1b89ab1.png)

No entanto, não tenho muita experiência com typeScript, e não sei se "getHexRoot ()" retornar object é uma boa opção...

Tive que colocar object como retorno da função, porque quando especifico como TLeafPref dá o erro que "leaf" não pode ser string (que é o que retorna o "bufferToHex").